### PR TITLE
Remove odd errorbar shifting

### DIFF
--- a/errorbar_groups.m
+++ b/errorbar_groups.m
@@ -241,23 +241,6 @@ if any(any(errorbar_lower~=0))||any(any(errorbar_upper~=0))
         end
     end
     
-    for grp=1:N_grps
-        if verLessThan('matlab', '8.4.0')
-            he_xdata=get(he_c{grp}(2),'XData');
-        else
-            he_xdata=get(he(grp), 'XData');
-        end
-        he_xdata(4:9:end)=he_xdata(1:9:end)-errorbar_width*bar_width/2;
-        he_xdata(7:9:end)=he_xdata(1:9:end)-errorbar_width*bar_width/2;
-        he_xdata(5:9:end)=he_xdata(1:9:end)+errorbar_width*bar_width/2;
-        he_xdata(8:9:end)=he_xdata(1:9:end)+errorbar_width*bar_width/2;
-        if verLessThan('matlab', '8.4.0')
-            set(he_c{grp}(2),'XData',he_xdata);
-        else
-            set(he(grp),'XData',he_xdata);
-        end
-    end
-    
 end
 
 % set the x tick labels


### PR DESCRIPTION
Deleted lines 244-259.  It seems that for some reason, the centers of some errorbars were being shifted for only a few of the bars.  Perhaps for some older matlab functionality??  Either way, it didn't seem to make sense since it only happened for bars 4, 5, 7, and 8, and they were always moved to the location of the 1st bar, not their respectively correct bars.  Removed those lines of code to have proper functionality in Matlab 9.1.  However, may have broken some sort of older functionality, but if that is the case then I would imagine another solution would be better to solve that problem.  Happy to discuss why those lines were there and how they could be fixed.

If they really are necessary, I'd suggest it being just an "if" statement, with everything necessary inside of the if statement.  Remove the else portions and changes there for any later matlab versions.